### PR TITLE
Remove support for CBC key wrapping

### DIFF
--- a/docs/macusage.md
+++ b/docs/macusage.md
@@ -65,11 +65,11 @@ Note: SHA-256 hash is used by default. SHA-1 hash can be used under request.
 
 ## Keys type and algorithms – 3DES
 
-|                  |                                                                                                                                                                                                                                                 |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| KI Key Type      | "3 key" 3DES (size 24 bytes) or "2 key" 3DES (size 16 bytes) (*)                                                                                                                                                                                |
-| MAC Key Type     | "2 key" 3DES (size 16 bytes)                                                                                                                                                                                                                    |
-| MAC Key wrapping | 3DES using CBC or ECB                                                                                                                                                                                                                           |
+|                  |                                                                                                                                                                                                                                                |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| KI Key Type      | "3 key" 3DES (size 24 bytes) or "2 key" 3DES (size 16 bytes) (*)                                                                                                                                                                               |
+| MAC Key Type     | "2 key" 3DES (size 16 bytes)                                                                                                                                                                                                                   |
+| MAC Key wrapping | 3DES using ECB                                                                                                                                                                                                                           |
 | MAC              | MAC Algorithm 3 (ISO 9797-1 Algorithm 3). Padding method 1 is used: input data is completed with `0`s until the data reaches a multiple of 8-byte blocks. No `0` is added if already a multiple. The MAC is the 8 leftmost bytes of the output. |
 
 (*) KI Key length depends to remote Host capability


### PR DESCRIPTION
This pull request includes a minor update to the `docs/macusage.md` file, specifically refining the description of the MAC key wrapping method for clarity and accuracy.

### Documentation Update:
* [`docs/macusage.md`](diffhunk://#diff-024b855d1cbe3cdac8caee9649a5c97dccee6b99d6078bdc7fc1932f91fee1abL69-R72): Updated the MAC Key wrapping method to specify the use of "3DES using ECB" instead of "3DES using CBC or ECB" for consistency with the intended implementation.
