### PR TITLE
Remove CTSP in onboarding.md, link iso docs in README and root page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
 Welcome to BankAxept's documentation.
 
-* [Getting Started with BankAxept CTSP Platform](./getting_started.md)
-* [CTSP API](./swagger/ctsp-token-api)
+* [Getting Started with STØ Token Service](./getting_started.md)
+* [STØ Token Service ISO API](./TSP_ISO_Message.md)

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,6 +1,6 @@
 # Onboarding
 
-This page describes all steps required to start utilizing Cloud TSP APIs. It includes a checklist of all necessary steps
+This page describes all steps required to start utilizing STØ Token Service APIs. It includes a checklist of all necessary steps
 and requirements, as well as a description of why they are required.
 
 There are two environments available: preproduction and production. The preproduction environment is used for testing
@@ -30,11 +30,3 @@ in the source IP needs to be communicated to BankAxept.
 
 A certificate signing request (CSR) needs to be provided to the Cloud TSP support team. Once the CSR is received, the
 support team will generate a certificate. This will be used to enable secure connectivity to the APIs.
-
-### Connectivity test
-
-The connectivity test is used to verify that the connectivity between the integrator and BankAxept is working as
-expected. The test is performed by the integrator with support by the Cloud TSP support team. An HTTP request, from
-BankAxept. The health check endpoint URL is: `https://api.bankaxept.com/health-check`.
-
-By verifying that the health check can be called successfully, the connectivity is considered to be working.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,12 +14,12 @@ nav:
   - Documentation:
       - Introduction: getting_started.md
       - Onboarding: onboarding.md
-      - Tokenization flows:
-          - Epayment: tokenization.md
       - Resources:
-          - API Policy: api_policy.md
-  - API Specs:
-      - BankAxept CTSP Integrator API: swagger/ctsp-token-api.md
+          - STØ Token Service ISO API v2.8 current: TSP_ISO_Message.md
+          - STØ Token Service ISO API v2.7: TSP_ISO_Message_V2.7.md
+          - STØ Token Service ISO API v2.6: TSP_ISO_Message_V2.6.md
+          - STØ Token Service ISO API v2.5: TSP_ISO_Message_V2.5.md
+
 extra_javascript:
   - https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js
   - https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js


### PR DESCRIPTION
This pull request updates the documentation to reflect changes in naming conventions and API structure, transitioning from "BankAxept CTSP Platform" to "STØ Token Service." It also removes outdated sections, simplifies navigation in `mkdocs.yml`, and introduces versioned API documentation.

### Updates to naming conventions and API references:
* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L3-R4): Updated links and titles to replace "BankAxept CTSP Platform" with "STØ Token Service" and added references to the ISO API documentation.
* [`docs/onboarding.md`](diffhunk://#diff-c09476a644a06b093b012c8be9e98d4bf9d1bde0da31eb3b21de3e85fef0c057L3-R3): Revised text to align with the new "STØ Token Service" terminology.

### Removal of outdated sections:
* [`docs/onboarding.md`](diffhunk://#diff-c09476a644a06b093b012c8be9e98d4bf9d1bde0da31eb3b21de3e85fef0c057L33-L40): Removed the "Connectivity test" section, which included instructions for verifying connectivity with BankAxept's health check endpoint.

### Simplification and restructuring of navigation:
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L17-R22): Updated navigation to reflect the new API structure, removed references to deprecated APIs, and added links to versioned "STØ Token Service ISO API" documentation (v2.5 through v2.8).